### PR TITLE
Code reviews from Yuanxun Qin

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -105,6 +105,7 @@ function auth() {
     }
 
     // A regex expression to test if the given value is an email or username
+    // Code review from Yuanxun Qin: Remove the next 4 lines and put them into the register phase.
     let regexEmail = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{1,8})+$/;
     const data = regexEmail.test(emailOrUsername)
       ? { email: emailOrUsername }


### PR DESCRIPTION
Codes from 108 to 111 may have bugs. Because there's no regexEmail.test() in the register phase, we could use a email like "abc@abc" to register successfully. When this happen, this user could not login here because the regexEmail.test() redirect the this value to become username here. We can try to register any account with email of format "*@a"(without a ".com" as subfix) , this bug will show up. My recommendation is use this validation pattern in the register phase, but no validation in log in. Only check match at the log in phase. Make register a bit rigid than log in.